### PR TITLE
Handle empty compile

### DIFF
--- a/src/hlcc/codeGen/js.ts
+++ b/src/hlcc/codeGen/js.ts
@@ -320,6 +320,7 @@ ${row.returnExpression ? "return" : ""} ${this.generate(row.returnExpression)};`
 }
 
 export function generate(hlFile: HLFileScope) {
+    if(!hlFile.allActions().length) { return; }
     const jsWriter = new JSWriter();
     hlFile.allActions().forEach(row => {
         jsWriter.writeAction(row);

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ switch (cmd) {
         logErrors(hlFile);
         console.log(`Compiled "${argv.file}"`);
         generate(hlFile);
+        if (!!!hlFile.text) { break; }
         console.log(`Running "${argv.file}"\n`);
         runScript(outPath(argv.file), function (err) {
             if (err) throw err;


### PR DESCRIPTION
If a file is compiled to have no code/the codeGen returns nothing, it will not create a file.
For example a file with exports only.

We do not want to attempt to run it as it wont exist AND we do not want to run any old files that were previously compiled.

*Adding check to make sure compiled file has content
*Removing and previous files if no file was created (so we dont run old file)